### PR TITLE
Fix minor errors in java docs

### DIFF
--- a/src/main/java/com/squareup/square/SquareClient.java
+++ b/src/main/java/com/squareup/square/SquareClient.java
@@ -715,7 +715,7 @@ public final class SquareClient implements SquareClientInterface {
         /**
          * The timeout to use for making HTTP requests.
          * @deprecated This method will be removed in a future version. Use
-         *             {@link #httpClientConfig()} instead.
+         *             {@link #httpClientConfig(Consumer)} instead.
          * @param timeout must be greater then 0.
          * @return Builder
          */

--- a/src/main/java/com/squareup/square/http/client/OkClient.java
+++ b/src/main/java/com/squareup/square/http/client/OkClient.java
@@ -172,6 +172,7 @@ public class OkClient implements HttpClient {
 
     /**
      * Converts a given OkHttp response into our internal http response model.
+     * @param   request            The given HttpRequest.
      * @param   response           The given OkHttp response.
      * @param   hasBinaryResponse  Whether the response is binary or string.
      * @return  The converted http response.


### PR DESCRIPTION
These errors were causing our java doc generation to fail.