### PR TITLE
Fixing issues with generating javadocs

### DIFF
--- a/src/main/java/com/squareup/square/http/client/OkClient.java
+++ b/src/main/java/com/squareup/square/http/client/OkClient.java
@@ -189,6 +189,7 @@ public class OkClient implements HttpClient {
 
     /**
      * Converts a given OkHttp response into our internal http response model.
+     * @param   request            The request passed in.
      * @param   response           The given OkHttp response.
      * @param   hasBinaryResponse  Whether the response is binary or string.
      * @return  The converted http response.

--- a/src/main/java/com/squareup/square/models/CreateCatalogImageRequest.java
+++ b/src/main/java/com/squareup/square/models/CreateCatalogImageRequest.java
@@ -63,9 +63,9 @@ public class CreateCatalogImageRequest {
      * corresponding type of catalog object. For example, if `type=ITEM`, the `CatalogObject`
      * instance must have the ITEM-specific data set on the `item_data` attribute. The resulting
      * `CatalogObject` instance is also a `CatalogItem` instance. In general, if
-     * `type=<OBJECT_TYPE>`, the `CatalogObject` instance must have the `<OBJECT_TYPE>`-specific
-     * data set on the `<object_type>_data` attribute. The resulting `CatalogObject` instance is
-     * also a `Catalog<ObjectType>` instance. For a more detailed discussion of the Catalog data
+     * `type=&lt;OBJECT_TYPE&gt;`, the `CatalogObject` instance must have the `&lt;OBJECT_TYPE&gt;`-specific
+     * data set on the `&lt;object_type&gt;_data` attribute. The resulting `CatalogObject` instance is
+     * also a `Catalog&lt;ObjectType&gt;` instance. For a more detailed discussion of the Catalog data
      * model, please see the [Design a
      * Catalog](https://developer.squareup.com/docs/catalog-api/design-a-catalog) guide.
      * @return Returns the CatalogObject

--- a/src/main/java/com/squareup/square/models/CreateCatalogImageResponse.java
+++ b/src/main/java/com/squareup/square/models/CreateCatalogImageResponse.java
@@ -55,9 +55,9 @@ public class CreateCatalogImageResponse {
      * corresponding type of catalog object. For example, if `type=ITEM`, the `CatalogObject`
      * instance must have the ITEM-specific data set on the `item_data` attribute. The resulting
      * `CatalogObject` instance is also a `CatalogItem` instance. In general, if
-     * `type=<OBJECT_TYPE>`, the `CatalogObject` instance must have the `<OBJECT_TYPE>`-specific
-     * data set on the `<object_type>_data` attribute. The resulting `CatalogObject` instance is
-     * also a `Catalog<ObjectType>` instance. For a more detailed discussion of the Catalog data
+     * `type=&lt;OBJECT_TYPE&gt;`, the `CatalogObject` instance must have the `&lt;OBJECT_TYPE&gt;`-specific
+     * data set on the `&lt;object_type&gt;_data` attribute. The resulting `CatalogObject` instance is
+     * also a `Catalog&lt;ObjectType&gt;` instance. For a more detailed discussion of the Catalog data
      * model, please see the [Design a
      * Catalog](https://developer.squareup.com/docs/catalog-api/design-a-catalog) guide.
      * @return Returns the CatalogObject

--- a/src/main/java/com/squareup/square/models/RetrieveCatalogObjectResponse.java
+++ b/src/main/java/com/squareup/square/models/RetrieveCatalogObjectResponse.java
@@ -60,9 +60,9 @@ public class RetrieveCatalogObjectResponse {
      * corresponding type of catalog object. For example, if `type=ITEM`, the `CatalogObject`
      * instance must have the ITEM-specific data set on the `item_data` attribute. The resulting
      * `CatalogObject` instance is also a `CatalogItem` instance. In general, if
-     * `type=<OBJECT_TYPE>`, the `CatalogObject` instance must have the `<OBJECT_TYPE>`-specific
-     * data set on the `<object_type>_data` attribute. The resulting `CatalogObject` instance is
-     * also a `Catalog<ObjectType>` instance. For a more detailed discussion of the Catalog data
+     * `type=&lt;OBJECT_TYPE&gt;`, the `CatalogObject` instance must have the `&lt;OBJECT_TYPE&gt;`-specific
+     * data set on the `&lt;object_type&gt;_data` attribute. The resulting `CatalogObject` instance is
+     * also a `Catalog&lt;ObjectType&gt;` instance. For a more detailed discussion of the Catalog data
      * model, please see the [Design a
      * Catalog](https://developer.squareup.com/docs/catalog-api/design-a-catalog) guide.
      * @return Returns the CatalogObject

--- a/src/main/java/com/squareup/square/models/UpsertCatalogObjectRequest.java
+++ b/src/main/java/com/squareup/square/models/UpsertCatalogObjectRequest.java
@@ -48,9 +48,9 @@ public class UpsertCatalogObjectRequest {
      * corresponding type of catalog object. For example, if `type=ITEM`, the `CatalogObject`
      * instance must have the ITEM-specific data set on the `item_data` attribute. The resulting
      * `CatalogObject` instance is also a `CatalogItem` instance. In general, if
-     * `type=<OBJECT_TYPE>`, the `CatalogObject` instance must have the `<OBJECT_TYPE>`-specific
-     * data set on the `<object_type>_data` attribute. The resulting `CatalogObject` instance is
-     * also a `Catalog<ObjectType>` instance. For a more detailed discussion of the Catalog data
+     * `type=&lt;OBJECT_TYPE&gt;`, the `CatalogObject` instance must have the `&lt;OBJECT_TYPE&gt;`-specific
+     * data set on the `&lt;object_type&gt;_data` attribute. The resulting `CatalogObject` instance is
+     * also a `Catalog&lt;ObjectType&gt;` instance. For a more detailed discussion of the Catalog data
      * model, please see the [Design a
      * Catalog](https://developer.squareup.com/docs/catalog-api/design-a-catalog) guide.
      * @return Returns the CatalogObject

--- a/src/main/java/com/squareup/square/models/UpsertCatalogObjectResponse.java
+++ b/src/main/java/com/squareup/square/models/UpsertCatalogObjectResponse.java
@@ -60,9 +60,9 @@ public class UpsertCatalogObjectResponse {
      * corresponding type of catalog object. For example, if `type=ITEM`, the `CatalogObject`
      * instance must have the ITEM-specific data set on the `item_data` attribute. The resulting
      * `CatalogObject` instance is also a `CatalogItem` instance. In general, if
-     * `type=<OBJECT_TYPE>`, the `CatalogObject` instance must have the `<OBJECT_TYPE>`-specific
-     * data set on the `<object_type>_data` attribute. The resulting `CatalogObject` instance is
-     * also a `Catalog<ObjectType>` instance. For a more detailed discussion of the Catalog data
+     * `type=&lt;OBJECT_TYPE&gt;`, the `CatalogObject` instance must have the `&lt;OBJECT_TYPE&gt;`-specific
+     * data set on the `&lt;object_type&gt;_data` attribute. The resulting `CatalogObject` instance is
+     * also a `Catalog&lt;ObjectType&gt;` instance. For a more detailed discussion of the Catalog data
      * model, please see the [Design a
      * Catalog](https://developer.squareup.com/docs/catalog-api/design-a-catalog) guide.
      * @return Returns the CatalogObject


### PR DESCRIPTION
The `<` and `>` characters are special in javadocs, as they denote tags. Escaping them to allow javadocs to be generated.