### PR TITLE
Increase staging release timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
                     </configuration>
                 </plugin>
                 <!-- To generate javadoc -->


### PR DESCRIPTION
Increase `stagingProgressTimeoutMinutes` from default of 5 minutes to 10 minutes to help with SDK publishing timeouts.