### PR TITLE
fix: updating sonatype references to s01.oss.sonatype.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
@@ -142,7 +142,7 @@
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
                     </configuration>


### PR DESCRIPTION
Sonatype's original oss.sonatype.org keeps timing out. Filed a ticket for them to upgrade us to the new infrastructure. 
They completed the migration and we need to update our references to `s01.oss.sonatype.org`.

[Sonatype ticket](https://issues.sonatype.org/browse/OSSRH-76167)