### PR TITLE
Depend on okhttp jvm for Maven consumers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,9 @@ repositories {
 }
 
 dependencies {
-    api 'com.squareup.okhttp3:okhttp:5.2.1'
+    // Maven ignores Gradle Module Metadata, so the okhttp KMP root artifact is an empty jar.
+    // Depend on okhttp-jvm so Maven consumers get the real JVM classes (see square/okhttp#8913).
+    api 'com.squareup.okhttp3:okhttp-jvm:5.2.1'
     api 'com.fasterxml.jackson.core:jackson-databind:2.18.6'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.6'
     api 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.6'


### PR DESCRIPTION
## Summary
Fixes #201.

OkHttp 5 publishes an empty Kotlin Multiplatform root jar. Gradle follows module metadata to the real JVM classes, but Maven ignores that metadata, so SDK consumers get `ClassNotFoundException` for `okhttp3` types. The published dependency now points at the okhttp jvm artifact so Maven resolves the classes transitively.

## Test plan
* [x] `./gradlew generatePomFileForMavenPublication` includes the okhttp jvm artifact
* [x] Compile classpath resolves the okhttp jvm dependency at 5.2.1
* [x] Root project QueryStringMapperTest passes